### PR TITLE
Add Support for Past-days Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The idea is to read from one or more `parent` calendar entities then copy the ev
     - Works as both `parent` and `child` if it's set up with two-way sync permissions.
 - Local Calendar:
     - Works as both `parent` and `child`.
+- Remote Calendar:
+    - Only works as `parent` because they are imported from remote.
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Type: Map
     - `days_to_sync` (optional):
         - **Type**: Integer
         - **Description**: The number of days into the future for which events should be synchronized. Default, 7.
+    - `days_to_sync_past` (optional):
+        - **Type**: Integer
+        - **Description**: The number of days into the past for which events should be synchronized. Default, 0.
     - `ignore_event_if_title_starts_with` (optional):
         - **Type**: String
         - **Description**: If an event title starts with this string, the event will be ignored during synchronization. Because sometimes the kids don't need to know everything going on 😉.

--- a/custom_components/family_calendar_sync/__init__.py
+++ b/custom_components/family_calendar_sync/__init__.py
@@ -61,6 +61,7 @@ def _normalize_copy_all_from(value):
 OPTIONS_SCHEMA = vol.Schema(
     {
         vol.Optional("days_to_sync", default=7): cv.positive_int,
+        vol.Optional("days_to_sync_past", default=0): cv.positive_int,
         vol.Optional("ignore_event_if_title_starts_with", default=""): cv.string,
     }
 )

--- a/custom_components/family_calendar_sync/const.py
+++ b/custom_components/family_calendar_sync/const.py
@@ -4,6 +4,7 @@ DOMAIN = "family_calendar_sync"
 SERVICE_SYNC = "family_calendar_sync"
 
 DEFAULT_DAYS_TO_SYNC = 7
+DEFAULT_DAYS_TO_SYNC_PAST = 0
 HASH_LENGTH = 8
 
 # Version where legacy map-based copy_all_from support will be removed.


### PR DESCRIPTION
This PR added an option to sync calendar events in the past. It defaults to 0 to maintain the current behaviour. It also fixes an error when an event is 0 length. That is possible when the other calendar is imported through ICS. 